### PR TITLE
fix(auth): surface real Better Auth error messages in login/register

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -25,11 +25,16 @@ export default function LoginPage() {
 
     try {
       const { error } = await signIn.email({ email, password })
-      if (error) throw error
+      if (error) {
+        const message =
+          (error as { message?: string }).message ??
+          "Couldn’t sign in. Check the address and try again."
+        throw new Error(message)
+      }
       toast.success("Welcome back.")
       router.push("/dashboard")
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Couldn’t sign in. Check the address and try again."
+      const message = error instanceof Error ? error.message : "Something went sideways."
       toast.error(message)
     } finally {
       setIsLoading(false)
@@ -40,9 +45,14 @@ export default function LoginPage() {
     setIsLoading(true)
     try {
       const { error } = await signIn.social({ provider, callbackURL: "/dashboard" })
-      if (error) throw error
+      if (error) {
+        const message =
+          (error as { message?: string }).message ??
+          `Couldn’t sign in with ${provider}.`
+        throw new Error(message)
+      }
     } catch (error) {
-      const message = error instanceof Error ? error.message : `Couldn’t sign in with ${provider}.`
+      const message = error instanceof Error ? error.message : "Something went sideways."
       toast.error(message)
     } finally {
       setIsLoading(false)

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -50,9 +50,14 @@ export default function RegisterPage() {
     setIsLoading(true)
     try {
       const { error } = await signIn.social({ provider, callbackURL: "/dashboard" })
-      if (error) throw error
+      if (error) {
+        const message =
+          (error as { message?: string }).message ??
+          `Couldn’t sign up with ${provider}.`
+        throw new Error(message)
+      }
     } catch (error) {
-      const message = error instanceof Error ? error.message : `Couldn’t sign up with ${provider}.`
+      const message = error instanceof Error ? error.message : "Something went sideways."
       toast.error(message)
     } finally {
       setIsLoading(false)


### PR DESCRIPTION
## Summary

Better Auth returns a plain `{ code, message, status }` object on failure, not an `Error` instance. The login page checked `instanceof Error` and fell through to a generic toast ("Couldn't sign in. Check the address and try again."), which hid both origin-trust errors (403) and credential errors (401). Register page already handled this for email signup but not for the social-login path.

Read `error.message` off the object directly in all four spots (login email, login social, register social — register email was already correct).

Discovered while debugging a Vercel sign-in failure where the underlying Better Auth error was an "Invalid origin" 403, fully invisible from the toast.

## Test plan

- [ ] `pnpm lint` clean
- [ ] On `vibe-voicer.vercel.app`, attempt sign-in with a wrong password → toast shows the real Better Auth message instead of the generic fallback
- [ ] Successful sign-in still works and routes to `/dashboard`