### PR TITLE
style: Tailwind v4 spacing + font-display canonicalization

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -11,9 +11,9 @@ export default function AboutPage() {
       <PublicNavigation />
 
       <section className="px-12 py-20">
-        <div className="mx-auto max-w-[820px]">
+        <div className="mx-auto max-w-205">
           <div className="t-overline">About</div>
-          <h1 className="font-display text-[64px] leading-[1.05] tracking-[-0.02em] mt-2 mb-8">
+          <h1 className="font-(--font-display) text-[64px] leading-[1.05] tracking-[-0.02em] mt-2 mb-8">
             We just wanted to <em className="italic">get paid</em>.
           </h1>
 
@@ -32,15 +32,15 @@ export default function AboutPage() {
           <div className="mt-16 grid grid-cols-1 md:grid-cols-3 gap-6">
             <div className="border-t border-border pt-4">
               <div className="t-overline mb-2">Built in</div>
-              <div className="font-display italic text-[24px]">Brooklyn</div>
+              <div className="font-(--font-display) italic text-[24px]">Brooklyn</div>
             </div>
             <div className="border-t border-border pt-4">
               <div className="t-overline mb-2">Year started</div>
-              <div className="font-display italic text-[24px]">2024</div>
+              <div className="font-(--font-display) italic text-[24px]">2024</div>
             </div>
             <div className="border-t border-border pt-4">
               <div className="t-overline mb-2">Team size</div>
-              <div className="font-display italic text-[24px]">Three</div>
+              <div className="font-(--font-display) italic text-[24px]">Three</div>
             </div>
           </div>
 

--- a/src/app/clients/[id]/page.tsx
+++ b/src/app/clients/[id]/page.tsx
@@ -71,7 +71,7 @@ export default function ClientDetailPage() {
   if (loading) {
     return (
       <ProtectedLayout>
-        <div className="flex items-center justify-center min-h-[400px]">
+        <div className="flex items-center justify-center min-h-100">
           <div className="h-px w-24 bg-ink-300 dark:bg-ink-700 animate-pulse" />
         </div>
       </ProtectedLayout>
@@ -81,8 +81,8 @@ export default function ClientDetailPage() {
   if (!client) {
     return (
       <ProtectedLayout>
-        <div className="flex flex-col items-center justify-center min-h-[400px] text-center gap-4">
-          <div className="font-display italic text-[40px]">Not here.</div>
+        <div className="flex flex-col items-center justify-center min-h-100 text-center gap-4">
+          <div className="font-(--font-display) italic text-[40px]">Not here.</div>
           <p className="text-(--fg-muted)">That client doesn’t exist or was deleted.</p>
           <Button asChild>
             <Link href="/clients">← Back to clients</Link>
@@ -188,7 +188,7 @@ export default function ClientDetailPage() {
               ) : (
                 <TableRow>
                   <TableCell colSpan={5} className="text-center py-12">
-                    <div className="font-display italic text-[20px] mb-2">No invoices yet.</div>
+                    <div className="font-(--font-display) italic text-[20px] mb-2">No invoices yet.</div>
                     <Button asChild>
                       <Link href="/invoices/new">Create the first one</Link>
                     </Button>

--- a/src/app/clients/new/page.tsx
+++ b/src/app/clients/new/page.tsx
@@ -64,7 +64,7 @@ export default function NewClientPage() {
 
   return (
     <ProtectedLayout title="New client" subtitle="Who are you billing this time?">
-      <div className="flex flex-col gap-4 max-w-[820px]">
+      <div className="flex flex-col gap-4 max-w-205">
         <Button asChild variant="ghost" size="sm" className="self-start">
           <Link href="/clients">
             <ArrowLeft className="h-3.5 w-3.5" />

--- a/src/app/clients/page.tsx
+++ b/src/app/clients/page.tsx
@@ -71,7 +71,7 @@ export default function ClientsPage() {
     <ProtectedLayout>
       <div className="flex flex-col gap-4">
         <div className="flex justify-between items-center">
-          <div className="flex items-center gap-2 px-2.5 py-1.5 rounded-[8px] border border-border bg-background text-(--fg-muted) w-[280px]">
+          <div className="flex items-center gap-2 px-2.5 py-1.5 rounded-[8px] border border-border bg-background text-(--fg-muted) w-70">
             <Search className="h-3.5 w-3.5" />
             <input
               type="search"
@@ -112,7 +112,7 @@ export default function ClientsPage() {
               ) : filtered.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={7} className="text-center py-12">
-                    <div className="font-display italic text-[24px] mb-2">No clients yet.</div>
+                    <div className="font-(--font-display) italic text-[24px] mb-2">No clients yet.</div>
                     <Button asChild>
                       <Link href="/clients/new">Add your first client</Link>
                     </Button>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -124,7 +124,7 @@ export default function DashboardPage() {
           <header className="flex justify-between items-end mb-4">
             <div>
               <div className="t-overline">Activity</div>
-              <h3 className="font-display text-[22px] leading-[1.1] mt-1">What just happened</h3>
+              <h3 className="font-(--font-display) text-[22px] leading-[1.1] mt-1">What just happened</h3>
             </div>
             <Button asChild variant="ghost" size="sm">
               <Link href="/invoices">View all →</Link>
@@ -162,7 +162,7 @@ export default function DashboardPage() {
             </ul>
           ) : (
             <div className="py-12 text-center">
-              <div className="font-display italic text-[24px] mb-2">No invoices yet.</div>
+              <div className="font-(--font-display) italic text-[24px] mb-2">No invoices yet.</div>
               <Button asChild size="default">
                 <Link href="/invoices/new">Create your first invoice</Link>
               </Button>
@@ -179,8 +179,8 @@ export default function DashboardPage() {
           </div>
 
           <div className="bg-(--bg-sunken) rounded-[12px] p-5 mt-2">
-            <div className="font-display italic text-[40px] leading-none text-(--fg-subtle)">&ldquo;</div>
-            <div className="font-display italic text-[20px] leading-[1.3] mt-1.5 mb-3">
+            <div className="font-(--font-display) italic text-[40px] leading-none text-(--fg-subtle)">&ldquo;</div>
+            <div className="font-(--font-display) italic text-[20px] leading-[1.3] mt-1.5 mb-3">
               Thursdays. People pay on Thursdays.
             </div>
             <div className="text-[11px] text-(--fg-muted)">— from your last 90 days</div>

--- a/src/app/features/page.tsx
+++ b/src/app/features/page.tsx
@@ -44,30 +44,30 @@ export default function FeaturesPage() {
       <PublicNavigation />
 
       <section className="px-12 py-20">
-        <div className="mx-auto max-w-[1100px] mb-10">
+        <div className="mx-auto max-w-275 mb-10">
           <div className="t-overline">Features</div>
-          <h1 className="font-display text-[64px] leading-[1.05] tracking-[-0.02em] mt-2 max-w-[820px]">
+          <h1 className="font-(--font-display) text-[64px] leading-[1.05] tracking-[-0.02em] mt-2 max-w-205">
             The boring parts, <em className="italic">handled</em>.
           </h1>
-          <p className="mt-4 text-[18px] text-(--fg-muted) max-w-[640px]">
+          <p className="mt-4 text-[18px] text-(--fg-muted) max-w-160">
             Everything Vibe Voicer does, in one read. Nothing here is optional bloat — it&rsquo;s all the stuff you would&rsquo;ve duct-taped together yourself.
           </p>
         </div>
 
-        <div className="mx-auto max-w-[1100px] grid grid-cols-1 md:grid-cols-2 gap-4 mb-10">
+        <div className="mx-auto max-w-275 grid grid-cols-1 md:grid-cols-2 gap-4 mb-10">
           {features.map((it) => (
             <div
               key={it.k}
               className="bg-(--bg-elevated) border border-border rounded-[16px] p-7 hover:border-(--border-strong) transition-colors"
             >
               <div className="font-mono text-[12px] text-(--fg-subtle) mb-4">{it.k}</div>
-              <div className="font-display text-[28px] leading-[1.1] mb-2.5">{it.h}</div>
-              <div className="text-[14px] text-(--fg-muted) leading-[1.55] max-w-[460px]">{it.b}</div>
+              <div className="font-(--font-display) text-[28px] leading-[1.1] mb-2.5">{it.h}</div>
+              <div className="text-[14px] text-(--fg-muted) leading-[1.55] max-w-115">{it.b}</div>
             </div>
           ))}
         </div>
 
-        <div className="mx-auto max-w-[1100px] flex flex-wrap items-center gap-3">
+        <div className="mx-auto max-w-275 flex flex-wrap items-center gap-3">
           <Button asChild size="lg">
             <Link href="/register">Start free — no card</Link>
           </Button>

--- a/src/app/i/[slug]/page.tsx
+++ b/src/app/i/[slug]/page.tsx
@@ -101,7 +101,7 @@ export default function PublicInvoicePage() {
   if (error || !invoice) {
     return (
       <div className="min-h-screen bg-background flex flex-col items-center justify-center p-8 text-center gap-4">
-        <div className="font-display italic text-[40px]">No invoice here.</div>
+        <div className="font-(--font-display) italic text-[40px]">No invoice here.</div>
         <p className="text-(--fg-muted) text-[14px] max-w-md">
           That share link is wrong, expired, or the invoice was deleted.
         </p>
@@ -114,7 +114,7 @@ export default function PublicInvoicePage() {
 
   return (
     <div className="min-h-screen bg-(--bg-sunken)">
-      <header className="flex items-center justify-between px-7 py-5 max-w-[920px] mx-auto">
+      <header className="flex items-center justify-between px-7 py-5 max-w-230 mx-auto">
         <Wordmark size="md" />
         <div className="flex items-center gap-2">
           <ThemeSelector />
@@ -127,12 +127,12 @@ export default function PublicInvoicePage() {
         </div>
       </header>
 
-      <main className="bg-background max-w-[920px] mx-auto px-12 py-12 border border-border rounded-none mb-16 shadow-(--shadow-raised)">
+      <main className="bg-background max-w-230 mx-auto px-12 py-12 border border-border rounded-none mb-16 shadow-(--shadow-raised)">
         {/* Top meta */}
         <div className="flex justify-between items-start gap-6 mb-9">
           <div>
             <div className="t-overline">Invoice</div>
-            <h1 className="font-display text-[64px] leading-[1.0] tracking-[-0.02em] mt-1">
+            <h1 className="font-(--font-display) text-[64px] leading-none tracking-[-0.02em] mt-1">
               <span className="font-mono text-[40px] tracking-[0]">{invoice.invoiceNumber}</span>
             </h1>
             <div className="text-[12px] text-(--fg-muted) mt-1.5">
@@ -177,8 +177,8 @@ export default function PublicInvoicePage() {
               <tr>
                 <th className="text-left t-overline pb-2 border-b border-border">Description</th>
                 <th className="text-right t-overline pb-2 border-b border-border w-[70px]">Qty</th>
-                <th className="text-right t-overline pb-2 border-b border-border w-[120px]">Rate</th>
-                <th className="text-right t-overline pb-2 border-b border-border w-[140px]">Amount</th>
+                <th className="text-right t-overline pb-2 border-b border-border w-30">Rate</th>
+                <th className="text-right t-overline pb-2 border-b border-border w-35">Amount</th>
               </tr>
             </thead>
             <tbody>
@@ -202,7 +202,7 @@ export default function PublicInvoicePage() {
 
         {/* Totals */}
         <div className="flex justify-end mb-3">
-          <div className="w-[300px] flex flex-col gap-1.5 text-[13px]">
+          <div className="w-75 flex flex-col gap-1.5 text-[13px]">
             {invoice.subtotal !== undefined && (
               <div className="flex justify-between">
                 <span>Subtotal</span>
@@ -227,7 +227,7 @@ export default function PublicInvoicePage() {
               </div>
             )}
             <div className="flex justify-between border-t border-ink-900 dark:border-foreground mt-1.5 pt-2.5 text-[18px]">
-              <span className="font-display italic text-[22px]">Total due</span>
+              <span className="font-(--font-display) italic text-[22px]">Total due</span>
               <span className="font-mono tabular-nums">{formatCurrency(invoice.total)}</span>
             </div>
           </div>

--- a/src/app/invoices/[id]/edit/page.tsx
+++ b/src/app/invoices/[id]/edit/page.tsx
@@ -185,7 +185,7 @@ export default function EditInvoicePage() {
   if (loading) {
     return (
       <ProtectedLayout>
-        <div className="flex items-center justify-center min-h-[400px]">
+        <div className="flex items-center justify-center min-h-100">
           <div className="h-px w-24 bg-ink-300 dark:bg-ink-700 animate-pulse" />
         </div>
       </ProtectedLayout>
@@ -195,8 +195,8 @@ export default function EditInvoicePage() {
   if (!invoice) {
     return (
       <ProtectedLayout>
-        <div className="flex flex-col items-center justify-center min-h-[400px] text-center gap-4">
-          <div className="font-display italic text-[40px]">Not here.</div>
+        <div className="flex flex-col items-center justify-center min-h-100 text-center gap-4">
+          <div className="font-(--font-display) italic text-[40px]">Not here.</div>
           <Button asChild>
             <Link href="/invoices">← Back to invoices</Link>
           </Button>
@@ -207,7 +207,7 @@ export default function EditInvoicePage() {
 
   return (
     <ProtectedLayout title={`Edit ${invoice.invoiceNumber}`} subtitle="Tweak the details, save when ready.">
-      <div className="flex flex-col gap-4 max-w-[920px]">
+      <div className="flex flex-col gap-4 max-w-230">
         <div className="flex items-center justify-between">
           <Button asChild variant="ghost" size="sm">
             <Link href={`/invoices/${invoiceId}`}>
@@ -494,7 +494,7 @@ export default function EditInvoicePage() {
                     </div>
                   )}
                   <div className="flex justify-between border-t border-ink-900 dark:border-foreground mt-2 pt-2.5 text-[18px]">
-                    <span className="font-display italic text-[22px]">Total</span>
+                    <span className="font-(--font-display) italic text-[22px]">Total</span>
                     <span className="font-mono tabular-nums">{formatCurrency(total)}</span>
                   </div>
                 </div>

--- a/src/app/invoices/[id]/page.tsx
+++ b/src/app/invoices/[id]/page.tsx
@@ -110,7 +110,7 @@ export default function InvoiceDetailPage() {
   if (loading) {
     return (
       <ProtectedLayout>
-        <div className="flex items-center justify-center min-h-[400px]">
+        <div className="flex items-center justify-center min-h-100">
           <div className="h-px w-24 bg-ink-300 dark:bg-ink-700 animate-pulse" />
         </div>
       </ProtectedLayout>
@@ -120,8 +120,8 @@ export default function InvoiceDetailPage() {
   if (!invoice) {
     return (
       <ProtectedLayout>
-        <div className="flex flex-col items-center justify-center min-h-[400px] text-center gap-4">
-          <div className="font-display italic text-[40px]">Not here.</div>
+        <div className="flex flex-col items-center justify-center min-h-100 text-center gap-4">
+          <div className="font-(--font-display) italic text-[40px]">Not here.</div>
           <p className="text-(--fg-muted)">That invoice doesn’t exist or was deleted.</p>
           <Button asChild>
             <Link href="/invoices">← Back to invoices</Link>
@@ -234,7 +234,7 @@ export default function InvoiceDetailPage() {
               </div>
               <div>
                 <div className="t-overline">Bill to</div>
-                <div className="font-display text-[22px] leading-[1.1] mt-1.5">{invoice.client.name}</div>
+                <div className="font-(--font-display) text-[22px] leading-[1.1] mt-1.5">{invoice.client.name}</div>
                 <div className="text-[12px] text-(--fg-muted) mt-1 leading-[1.5]">
                   {invoice.client.email}
                   {invoice.client.phone && (
@@ -259,9 +259,9 @@ export default function InvoiceDetailPage() {
               <thead>
                 <tr>
                   <th className="text-left t-overline pb-2 border-b border-border">Description</th>
-                  <th className="text-right t-overline pb-2 border-b border-border w-[60px]">Qty</th>
-                  <th className="text-right t-overline pb-2 border-b border-border w-[120px]">Rate</th>
-                  <th className="text-right t-overline pb-2 border-b border-border w-[140px]">Amount</th>
+                  <th className="text-right t-overline pb-2 border-b border-border w-15">Qty</th>
+                  <th className="text-right t-overline pb-2 border-b border-border w-30">Rate</th>
+                  <th className="text-right t-overline pb-2 border-b border-border w-35">Amount</th>
                 </tr>
               </thead>
               <tbody>
@@ -277,7 +277,7 @@ export default function InvoiceDetailPage() {
             </table>
 
             <div className="flex justify-end mt-5">
-              <div className="w-[280px] flex flex-col gap-1.5 text-[13px]">
+              <div className="w-70 flex flex-col gap-1.5 text-[13px]">
                 <div className="flex justify-between">
                   <span>Subtotal</span>
                   <span className="font-mono tabular-nums">{formatCurrency(invoice.subtotal)}</span>
@@ -289,7 +289,7 @@ export default function InvoiceDetailPage() {
                   </div>
                 )}
                 <div className="flex justify-between border-t border-ink-900 dark:border-foreground mt-1.5 pt-2.5 text-[18px]">
-                  <span className="font-display italic text-[22px]">Total</span>
+                  <span className="font-(--font-display) italic text-[22px]">Total</span>
                   <span className="font-mono tabular-nums">{formatCurrency(invoice.total)}</span>
                 </div>
               </div>

--- a/src/app/invoices/new/page.tsx
+++ b/src/app/invoices/new/page.tsx
@@ -160,7 +160,7 @@ export default function NewInvoicePage() {
 
   return (
     <ProtectedLayout>
-      <div className="flex flex-col gap-4 max-w-[920px]">
+      <div className="flex flex-col gap-4 max-w-230">
         <div className="flex items-center justify-between">
           <Button asChild variant="ghost" size="sm">
             <Link href="/invoices">
@@ -459,7 +459,7 @@ export default function NewInvoicePage() {
                     </div>
                   )}
                   <div className="flex justify-between border-t border-ink-900 dark:border-foreground mt-2 pt-2.5 text-[18px]">
-                    <span className="font-display italic text-[22px]">Total</span>
+                    <span className="font-(--font-display) italic text-[22px]">Total</span>
                     <span className="font-mono tabular-nums">{formatCurrency(total)}</span>
                   </div>
                 </div>

--- a/src/app/invoices/page.tsx
+++ b/src/app/invoices/page.tsx
@@ -146,7 +146,7 @@ export default function InvoicesPage() {
             ))}
           </div>
           <div className="flex items-center gap-2">
-            <div className="flex items-center gap-2 px-2.5 py-1.5 rounded-[8px] border border-border bg-background text-(--fg-muted) w-[280px]">
+            <div className="flex items-center gap-2 px-2.5 py-1.5 rounded-[8px] border border-border bg-background text-(--fg-muted) w-70">
               <Search className="h-3.5 w-3.5" />
               <input
                 type="search"
@@ -189,7 +189,7 @@ export default function InvoicesPage() {
               ) : filtered.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={7} className="text-center py-12">
-                    <div className="font-display italic text-[24px] mb-2">No invoices yet.</div>
+                    <div className="font-(--font-display) italic text-[24px] mb-2">No invoices yet.</div>
                     <Button asChild>
                       <Link href="/invoices/new">Create your first invoice</Link>
                     </Button>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -92,7 +92,7 @@ export default function Home() {
 
       {/* Hero */}
       <section className="relative px-12 pt-20 pb-12">
-        <div className="mx-auto max-w-[1100px]">
+        <div className="mx-auto max-w-275">
           <div className="inline-flex items-center gap-2 text-[12px] text-(--fg-muted) px-3 py-1.5 border border-border rounded-full mb-7">
             <span
               aria-hidden
@@ -100,7 +100,7 @@ export default function Home() {
             />
             For freelancers who&rsquo;d rather be designing
           </div>
-          <h1 className="font-display leading-[1.0] tracking-[-0.02em] m-0 mb-7 max-w-[1000px]" style={{ fontSize: "clamp(56px, 9vw, 124px)" }}>
+          <h1 className="font-(--font-display) leading-none tracking-[-0.02em] m-0 mb-7 max-w-250" style={{ fontSize: "clamp(56px, 9vw, 124px)" }}>
             Get{" "}
             <em className="not-italic">
               <span className="italic">paid</span>
@@ -114,7 +114,7 @@ export default function Home() {
             <br />
             you mean it.
           </h1>
-          <p className="text-[20px] leading-[1.55] text-(--fg-muted) max-w-[640px] mb-8">
+          <p className="text-[20px] leading-[1.55] text-(--fg-muted) max-w-160 mb-8">
             Invoicing that doesn&rsquo;t feel like homework. Send a clean invoice, see when your client opens it, and quit chasing payments through three different apps.
           </p>
           <div className="flex flex-wrap gap-3 items-center mb-7">
@@ -133,13 +133,13 @@ export default function Home() {
             <span className="font-mono tabular-nums">No annual contracts</span>
           </div>
         </div>
-        <PerforatedEdge className="absolute left-0 right-0 bottom-[-1px]" />
+        <PerforatedEdge className="absolute left-0 right-0 -bottom-px" />
       </section>
 
       {/* Proof */}
       <section className="px-12 py-9 border-t border-b border-border">
-        <div className="mx-auto max-w-[1100px] flex flex-wrap items-center justify-between gap-9">
-          <div className="font-display italic text-[22px] text-(--fg-muted)">
+        <div className="mx-auto max-w-275 flex flex-wrap items-center justify-between gap-9">
+          <div className="font-(--font-display) italic text-[22px] text-(--fg-muted)">
             &ldquo;Stopped using three apps for one job. Final form.&rdquo;
           </div>
           <div className="flex gap-8">
@@ -149,7 +149,7 @@ export default function Home() {
               { num: "11k", lab: "Freelancers, no agencies" },
             ].map((s) => (
               <div key={s.lab}>
-                <div className="font-display text-[32px] leading-none">{s.num}</div>
+                <div className="font-(--font-display) text-[32px] leading-none">{s.num}</div>
                 <div className="t-overline mt-1">{s.lab}</div>
               </div>
             ))}
@@ -159,21 +159,21 @@ export default function Home() {
 
       {/* Features */}
       <section id="features" className="px-12 py-20 bg-(--bg-sunken)">
-        <div className="mx-auto max-w-[1100px] mb-9">
+        <div className="mx-auto max-w-275 mb-9">
           <div className="t-overline">What it does</div>
-          <h2 className="font-display text-[56px] leading-[1.05] mt-2 max-w-[720px]">
+          <h2 className="font-(--font-display) text-[56px] leading-[1.05] mt-2 max-w-180">
             The boring parts, <em className="italic">handled</em>.
           </h2>
         </div>
-        <div className="mx-auto max-w-[1100px] grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="mx-auto max-w-275 grid grid-cols-1 md:grid-cols-2 gap-4">
           {features.map((it) => (
             <div
               key={it.k}
               className="bg-(--bg-elevated) border border-border rounded-[16px] p-7 hover:border-(--border-strong) transition-colors"
             >
               <div className="font-mono text-[12px] text-(--fg-subtle) mb-4">{it.k}</div>
-              <div className="font-display text-[28px] leading-[1.1] mb-2.5">{it.h}</div>
-              <div className="text-[14px] text-(--fg-muted) leading-[1.55] max-w-[420px]">{it.b}</div>
+              <div className="font-(--font-display) text-[28px] leading-[1.1] mb-2.5">{it.h}</div>
+              <div className="text-[14px] text-(--fg-muted) leading-[1.55] max-w-105">{it.b}</div>
             </div>
           ))}
         </div>
@@ -181,13 +181,13 @@ export default function Home() {
 
       {/* Pricing */}
       <section id="pricing" className="px-12 py-20">
-        <div className="mx-auto max-w-[1100px] mb-10">
+        <div className="mx-auto max-w-275 mb-10">
           <div className="t-overline">Pricing</div>
-          <h2 className="font-display text-[52px] leading-[1.05] mt-2">
+          <h2 className="font-(--font-display) text-[52px] leading-[1.05] mt-2">
             Pay <em className="italic">monthly</em>. Cancel anytime.
           </h2>
         </div>
-        <div className="mx-auto max-w-[1100px] grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="mx-auto max-w-275 grid grid-cols-1 md:grid-cols-3 gap-4">
           {tiers.map((t) => (
             <div
               key={t.name}
@@ -203,9 +203,9 @@ export default function Home() {
                   Most picked
                 </div>
               )}
-              <div className="font-display italic text-[22px] leading-none">{t.name}</div>
+              <div className="font-(--font-display) italic text-[22px] leading-none">{t.name}</div>
               <div className="flex items-baseline gap-1.5">
-                <span className="font-display text-[56px] leading-none tracking-[-0.02em]">
+                <span className="font-(--font-display) text-[56px] leading-none tracking-[-0.02em]">
                   {t.price}
                 </span>
                 <span className={"text-[13px] " + (t.highlight ? "text-ink-700" : "text-(--fg-muted)")}>

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -48,17 +48,17 @@ export default function PricingPage() {
       <PublicNavigation />
 
       <section className="px-12 py-20">
-        <div className="mx-auto max-w-[1100px] mb-10">
+        <div className="mx-auto max-w-275 mb-10">
           <div className="t-overline">Pricing</div>
-          <h1 className="font-display text-[64px] leading-[1.05] tracking-[-0.02em] mt-2">
+          <h1 className="font-(--font-display) text-[64px] leading-[1.05] tracking-[-0.02em] mt-2">
             Pay <em className="italic">monthly</em>. Cancel anytime.
           </h1>
-          <p className="mt-4 text-[18px] text-(--fg-muted) max-w-[560px]">
+          <p className="mt-4 text-[18px] text-(--fg-muted) max-w-140">
             One price, billed monthly. No annual contracts, no per-invoice fees, no upsells we hide in the footer.
           </p>
         </div>
 
-        <div className="mx-auto max-w-[1100px] grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="mx-auto max-w-275 grid grid-cols-1 md:grid-cols-3 gap-4">
           {tiers.map((t) => (
             <div
               key={t.name}
@@ -74,9 +74,9 @@ export default function PricingPage() {
                   Most picked
                 </div>
               )}
-              <div className="font-display italic text-[22px] leading-none">{t.name}</div>
+              <div className="font-(--font-display) italic text-[22px] leading-none">{t.name}</div>
               <div className="flex items-baseline gap-1.5">
-                <span className="font-display text-[56px] leading-none tracking-[-0.02em]">
+                <span className="font-(--font-display) text-[56px] leading-none tracking-[-0.02em]">
                   {t.price}
                 </span>
                 <span className={"text-[13px] " + (t.highlight ? "text-ink-700" : "text-(--fg-muted)")}>
@@ -113,7 +113,7 @@ export default function PricingPage() {
           ))}
         </div>
 
-        <div className="mx-auto max-w-[1100px] mt-16 grid grid-cols-1 md:grid-cols-3 gap-4 text-[13px] text-(--fg-muted)">
+        <div className="mx-auto max-w-275 mt-16 grid grid-cols-1 md:grid-cols-3 gap-4 text-[13px] text-(--fg-muted)">
           <div className="border-t border-border pt-4">
             <div className="t-overline mb-2">Refunds</div>
             <p>14-day money back. No forms, no questions, just email us.</p>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -5,9 +5,9 @@ export default function PrivacyPage() {
   return (
     <div className="min-h-screen bg-background">
       <PublicNavigation />
-      <main className="mx-auto max-w-[760px] px-12 py-20">
+      <main className="mx-auto max-w-190 px-12 py-20">
         <div className="t-overline">Privacy</div>
-        <h1 className="font-display text-[64px] leading-[1.05] tracking-[-0.02em] mt-2 mb-8">
+        <h1 className="font-(--font-display) text-[64px] leading-[1.05] tracking-[-0.02em] mt-2 mb-8">
           The <em className="italic">policy</em>.
         </h1>
         <div className="text-[12px] text-(--fg-muted) mb-10">
@@ -16,25 +16,25 @@ export default function PrivacyPage() {
 
         <div className="flex flex-col gap-8 text-[15px] leading-[1.7]">
           <section>
-            <h2 className="font-display text-[28px] leading-[1.2] mb-3">What we collect</h2>
+            <h2 className="font-(--font-display) text-[28px] leading-[1.2] mb-3">What we collect</h2>
             <p className="text-(--fg-muted)">
               The bare minimum to make invoicing work — your name, email, and the invoice data you create. We don&rsquo;t buy data, sell data, or run third-party trackers.
             </p>
           </section>
           <section>
-            <h2 className="font-display text-[28px] leading-[1.2] mb-3">How we use it</h2>
+            <h2 className="font-(--font-display) text-[28px] leading-[1.2] mb-3">How we use it</h2>
             <p className="text-(--fg-muted)">
               To provide the service, send the invoices you tell us to send, and reply when you write to us. That&rsquo;s the whole list.
             </p>
           </section>
           <section>
-            <h2 className="font-display text-[28px] leading-[1.2] mb-3">Security</h2>
+            <h2 className="font-(--font-display) text-[28px] leading-[1.2] mb-3">Security</h2>
             <p className="text-(--fg-muted)">
               Encrypted in transit and at rest. Sessions are short. Passwords are hashed. The basics, done right.
             </p>
           </section>
           <section>
-            <h2 className="font-display text-[28px] leading-[1.2] mb-3">Contact</h2>
+            <h2 className="font-(--font-display) text-[28px] leading-[1.2] mb-3">Contact</h2>
             <p className="text-(--fg-muted)">
               Questions? <a className="text-foreground underline underline-offset-4" href="mailto:privacy@vibevoicer.com">privacy@vibevoicer.com</a>
             </p>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -140,7 +140,7 @@ export default function SettingsPage() {
 
   return (
     <ProtectedLayout>
-      <div className="max-w-[920px]">
+      <div className="max-w-230">
         <Tabs defaultValue="personal">
           <TabsList>
             <TabsTrigger value="personal">Personal</TabsTrigger>
@@ -262,7 +262,7 @@ export default function SettingsPage() {
               <p className="text-[12px] text-(--fg-muted) mt-0.5 mb-6">
                 We&rsquo;ll sign you out of other sessions when you change it.
               </p>
-              <div className="flex flex-col gap-4 max-w-[420px]">
+              <div className="flex flex-col gap-4 max-w-105">
                 <div className="flex flex-col gap-1.5">
                   <Label htmlFor="currentPassword">Current password</Label>
                   <Input

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -5,9 +5,9 @@ export default function TermsPage() {
   return (
     <div className="min-h-screen bg-background">
       <PublicNavigation />
-      <main className="mx-auto max-w-[760px] px-12 py-20">
+      <main className="mx-auto max-w-190 px-12 py-20">
         <div className="t-overline">Terms</div>
-        <h1 className="font-display text-[64px] leading-[1.05] tracking-[-0.02em] mt-2 mb-8">
+        <h1 className="font-(--font-display) text-[64px] leading-[1.05] tracking-[-0.02em] mt-2 mb-8">
           The fine <em className="italic">print</em>.
         </h1>
         <div className="text-[12px] text-(--fg-muted) mb-10">
@@ -16,25 +16,25 @@ export default function TermsPage() {
 
         <div className="flex flex-col gap-8 text-[15px] leading-[1.7]">
           <section>
-            <h2 className="font-display text-[28px] leading-[1.2] mb-3">Using Vibe Voicer</h2>
+            <h2 className="font-(--font-display) text-[28px] leading-[1.2] mb-3">Using Vibe Voicer</h2>
             <p className="text-(--fg-muted)">
               Use it for legitimate invoicing — yours or your clients&rsquo;. Don&rsquo;t use it to scam, spam, or impersonate anyone. We can suspend accounts that do.
             </p>
           </section>
           <section>
-            <h2 className="font-display text-[28px] leading-[1.2] mb-3">Your account</h2>
+            <h2 className="font-(--font-display) text-[28px] leading-[1.2] mb-3">Your account</h2>
             <p className="text-(--fg-muted)">
               You&rsquo;re responsible for keeping your credentials safe and for what happens under your account. Don&rsquo;t share your password.
             </p>
           </section>
           <section>
-            <h2 className="font-display text-[28px] leading-[1.2] mb-3">Service availability</h2>
+            <h2 className="font-(--font-display) text-[28px] leading-[1.2] mb-3">Service availability</h2>
             <p className="text-(--fg-muted)">
               We aim for the best uptime we can. We don&rsquo;t promise zero downtime — nobody honestly can. We&rsquo;ll be straight with you when something breaks.
             </p>
           </section>
           <section>
-            <h2 className="font-display text-[28px] leading-[1.2] mb-3">Contact</h2>
+            <h2 className="font-(--font-display) text-[28px] leading-[1.2] mb-3">Contact</h2>
             <p className="text-(--fg-muted)">
               <a className="text-foreground underline underline-offset-4" href="mailto:legal@vibevoicer.com">legal@vibevoicer.com</a>
             </p>

--- a/src/components/app-topbar.tsx
+++ b/src/components/app-topbar.tsx
@@ -14,12 +14,12 @@ export function AppTopbar({ title, subtitle }: AppTopbarProps) {
   return (
     <header className="sticky top-0 z-20 flex items-center justify-between gap-6 px-7 py-4 border-b border-border bg-background">
       <div className="flex flex-col gap-0.5 min-w-0">
-        <h1 className="font-display text-[28px] leading-[1.1] truncate">{title}</h1>
+        <h1 className="font-(--font-display) text-[28px] leading-[1.1] truncate">{title}</h1>
         {subtitle && <div className="text-[12px] text-(--fg-muted)">{subtitle}</div>}
       </div>
 
       <div className="flex items-center gap-2">
-        <div className="hidden md:flex items-center gap-2 px-2.5 py-1.5 w-[320px] rounded-[8px] border border-border bg-(--bg-sunken) text-(--fg-muted)">
+        <div className="hidden md:flex items-center gap-2 px-2.5 py-1.5 w-80 rounded-[8px] border border-border bg-(--bg-sunken) text-(--fg-muted)">
           <Search className="h-3.5 w-3.5" />
           <input
             type="search"

--- a/src/components/auth-shell.tsx
+++ b/src/components/auth-shell.tsx
@@ -16,7 +16,7 @@ export function AuthShell({ side, overline, heading, children }: AuthShellProps)
       <aside className="hidden lg:flex flex-col justify-between p-12 border-r border-border bg-(--bg-sunken)">
         <Wordmark size="lg" />
         <div>
-          <div className="font-display italic text-[36px] leading-[1.2] text-foreground">
+          <div className="font-(--font-display) italic text-[36px] leading-[1.2] text-foreground">
             &ldquo;{side.quote}&rdquo;
           </div>
           {side.caption && (
@@ -36,9 +36,9 @@ export function AuthShell({ side, overline, heading, children }: AuthShellProps)
           </div>
         </div>
         <div className="flex-1 flex items-center justify-center px-6 lg:px-12 py-10">
-          <div className="w-full max-w-[420px]">
+          <div className="w-full max-w-105">
             <div className="t-overline mb-3">{overline}</div>
-            <h1 className="font-display text-[64px] leading-[1.0] tracking-[-0.02em] mb-8 max-w-[400px]">
+            <h1 className="font-(--font-display) text-[64px] leading-none tracking-[-0.02em] mb-8 max-w-100">
               {heading}
             </h1>
             {children}

--- a/src/components/brand/mark.tsx
+++ b/src/components/brand/mark.tsx
@@ -16,7 +16,7 @@ export function Mark({ size = 32, className }: MarkProps) {
       aria-hidden
     >
       <span
-        className="font-display italic text-citrus dark:text-ink-900 leading-none"
+        className="font-(--font-display) italic text-citrus dark:text-ink-900 leading-none"
         style={{ fontSize: size * 0.7 }}
       >
         V

--- a/src/components/brand/wordmark.tsx
+++ b/src/components/brand/wordmark.tsx
@@ -17,7 +17,7 @@ export function Wordmark({ size = "md", className, showDot = true }: WordmarkPro
   const fontPx = SIZE_PX[size]
   return (
     <span
-      className={cn("inline-flex items-baseline leading-none font-display", className)}
+      className={cn("inline-flex items-baseline leading-none font-(--font-display)", className)}
       style={{ fontSize: fontPx }}
     >
       <span>Vibe</span>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -13,7 +13,7 @@ const links = [
 export function Footer() {
   return (
     <footer className="border-t border-border px-12 py-8">
-      <div className="mx-auto max-w-[1280px] flex flex-col gap-4 md:flex-row md:items-center md:justify-between text-[12px]">
+      <div className="mx-auto max-w-320 flex flex-col gap-4 md:flex-row md:items-center md:justify-between text-[12px]">
         <div className="flex items-center gap-4">
           <Wordmark size="sm" />
           <span className="text-(--fg-muted)">© {new Date().getFullYear()} · Made for people who&rsquo;d rather be doing the work.</span>

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -43,7 +43,7 @@ export function AppSidebar() {
     : "·"
 
   return (
-    <aside className="sticky top-0 h-screen w-[248px] flex flex-col p-3 border-r border-border bg-background">
+    <aside className="sticky top-0 h-screen w-62 flex flex-col p-3 border-r border-border bg-background">
       {/* Workspace switcher */}
       <div className="flex items-center gap-2.5 p-2.5 rounded-[10px] border border-border mb-4 cursor-pointer hover:bg-(--bg-sunken) transition-colors">
         <Mark size={32} />
@@ -95,7 +95,7 @@ export function AppSidebar() {
               <ChevronDown className="h-3.5 w-3.5 text-(--fg-subtle)" />
             </button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="min-w-[12rem]">
+          <DropdownMenuContent align="end" className="min-w-48">
             <DropdownMenuItem asChild>
               <Link href="/settings">
                 <Settings className="h-4 w-4" />

--- a/src/components/public-navigation.tsx
+++ b/src/components/public-navigation.tsx
@@ -14,7 +14,7 @@ const links = [
 export function PublicNavigation() {
   return (
     <header className="sticky top-0 z-50 border-b border-border bg-[color-mix(in_srgb,var(--background)_80%,transparent)] backdrop-blur-[12px]">
-      <div className="mx-auto max-w-[1280px] px-12 py-3.5 flex items-center justify-between gap-6">
+      <div className="mx-auto max-w-320 px-12 py-3.5 flex items-center justify-between gap-6">
         <Link href="/" aria-label="Vibe Voicer home" className="flex items-center">
           <Wordmark size="lg" />
         </Link>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -32,7 +32,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-title"
-      className={cn("font-display text-[22px] leading-[1.1]", className)}
+      className={cn("font-(--font-display) text-[22px] leading-[1.1]", className)}
       {...props}
     />
   )

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -42,7 +42,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-(--bg-elevated) text-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[10rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-[8px] border border-border p-1 shadow-(--shadow-floating)",
+          "bg-(--bg-elevated) text-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-40 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-[8px] border border-border p-1 shadow-(--shadow-floating)",
           className
         )}
         {...props}
@@ -230,7 +230,7 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
         className
       )}
       {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -61,7 +61,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-32 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className


### PR DESCRIPTION
Follow-up to b46e558. Tailwind language-server flagged more `suggestCanonicalClasses` warnings:

- `font-display` → `font-(--font-display)` (LSP prefers paren syntax for fonts in this config)
- arbitrary px values divisible by 4 → dynamic spacing scale (e.g. `max-w-[1100px]` → `max-w-275`)
- `min-w-[Nrem]` (8/10/12) → `min-w-32/40/48`
- `bottom-[-1px]` → `-bottom-px`
- `leading-[1.0]` → `leading-none`

Skipped: non-divisible-by-4 px values (5px, 11px, 9px, 70px, 2px) — no exact Tailwind scale match.

## Test plan

- [ ] `pnpm lint` clean
- [ ] `pnpm build` clean (verified locally)
- [ ] No visual regressions in dashboard / invoices / clients / public marketing